### PR TITLE
feat: add options page for user settings (dark mode, refresh interval…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,5 +34,9 @@
       "resources": ["libs/*"],
       "matches": ["<all_urls>"]
     }
-  ]
+  ],
+    "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": false
+  }
 }

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,19 @@
+body {
+  font-family: system-ui, sans-serif;
+  padding: 16px;
+}
+
+main {
+  max-width: 600px;
+  margin: auto;
+}
+
+label {
+  display: block;
+  margin: 12px 0;
+}
+
+button {
+  padding: 8px 12px;
+  cursor: pointer;
+}

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MarkIt Settings</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Extension Settings</h1>
+
+      <label>
+        <input type="checkbox" id="darkMode" />
+        Enable Dark Mode
+      </label>
+
+      <label>
+        Auto Refresh Interval (seconds):
+        <input type="number" id="refreshInterval" min="0" step="1" />
+      </label>
+
+      <label>
+        Export Format:
+        <select id="exportFormat">
+          <option value="json">JSON</option>
+          <option value="csv">CSV</option>
+          <option value="txt">TXT</option>
+        </select>
+      </label>
+
+      <div>
+        <button id="save">Save Settings</button>
+        <span id="status"></span>
+      </div>
+    </main>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,29 @@
+const DEFAULTS = {
+  darkMode: false,
+  refreshInterval: 0,
+  exportFormat: 'json'
+};
+
+document.addEventListener('DOMContentLoaded', restoreSettings);
+document.getElementById('save').addEventListener('click', saveSettings);
+
+async function restoreSettings() {
+  const result = await chrome.storage.sync.get(DEFAULTS);
+  document.getElementById('darkMode').checked = result.darkMode;
+  document.getElementById('refreshInterval').value = result.refreshInterval;
+  document.getElementById('exportFormat').value = result.exportFormat;
+}
+
+async function saveSettings() {
+  const data = {
+    darkMode: document.getElementById('darkMode').checked,
+    refreshInterval: Number(document.getElementById('refreshInterval').value || 0),
+    exportFormat: document.getElementById('exportFormat').value
+  };
+
+  await chrome.storage.sync.set(data);
+  document.getElementById('status').textContent = 'Saved!';
+  setTimeout(() => (document.getElementById('status').textContent = ''), 1500);
+
+  chrome.runtime.sendMessage({ type: 'settings-updated', payload: data });
+}


### PR DESCRIPTION
- Added options page for user settings
- Implemented chrome.storage.sync to persist user preferences
- Added options_ui in manifest.json
- Background script listens to settings changes
- Fixes #5
