### PR TITLE
Feature: Added Export Highlights feature (JSON & CSV support)

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -449,6 +449,13 @@
       <button id="exportJsonBtn" class="sub-btn">Export to JSON</button>
       <button id="importJsonBtn" class="sub-btn">Import from JSON</button>
     </div>
+     <!-- Export Buttons Section -->
+
+  <div id="export-section" style="margin-top: 10px;">
+    <button id="export-json">Export as JSON</button>
+    <button id="export-csv">Export as CSV</button>
+  </div>
+    
   </div>
 
   <!-- Local jsPDF -->

--- a/popup.js
+++ b/popup.js
@@ -510,4 +510,45 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Refresh highlights every 3 seconds when popup is open
     setInterval(loadHighlights, 3000);
+
+    // ~Export highlights to JSON file
+function exportToJSON(highlights) {
+  const blob = new Blob([JSON.stringify(highlights, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "highlights.json";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+// ~Export highlights to CSV file
+function exportToCSV(highlights) {
+  if (!highlights.length) return;
+  const headers = Object.keys(highlights[0]);
+  const rows = highlights.map(obj => headers.map(header => JSON.stringify(obj[header] || "")).join(","));
+  const csv = [headers.join(","), ...rows].join("\n");
+
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "highlights.csv";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+// ~Handle JSON export button click
+document.getElementById("export-json").addEventListener("click", () => {
+  chrome.storage.local.get("highlights", (result) => {
+    const highlights = result.highlights || [];
+    exportToJSON(highlights);
+  });
+});
+// ~Handle CSV export button click
+document.getElementById("export-csv").addEventListener("click", () => {
+  chrome.storage.local.get("highlights", (result) => {
+    const highlights = result.highlights || [];
+    exportToCSV(highlights);
+  });
+});
+
 });


### PR DESCRIPTION
FIXES | ISSUE NUMBER 12
This update adds the ability to export saved highlights in JSON and CSV formats.
Implemented export buttons in 'popup.html' and logic in 'popup.js' using the Blob API and chrome.storage.local.
Ensures "storage" permission is included in 'manifest.json'.