### PR TITLE
Path Sum III | Count Paths with Target Sum using DFS & Prefix Sum

### DIFF
--- a/pathSumIII.java
+++ b/pathSumIII.java
@@ -1,0 +1,17 @@
+class Solution {
+    int total = 0;
+    public int pathSum(TreeNode root, int targetSum) {
+        if(root == null) return 0;
+        solve(root , targetSum , 0);
+        pathSum(root.left , targetSum);
+        pathSum(root.right , targetSum);
+        return total;
+    }
+    public void solve(TreeNode r , int t ,long sum){
+        if(r == null) return;
+        sum+=r.val;
+        if(t == sum) total++;
+        solve(r.left , t , sum);
+        solve(r.right , t , sum);
+    }
+}


### PR DESCRIPTION
The Path Sum III problem is a classic binary tree challenge that tests your understanding of recursion, depth-first search (DFS), and prefix sum optimization.

Given the root of a binary tree and an integer targetSum, the task is to count the total number of paths where the sum of all node values along the path equals targetSum.
A path does not need to start or end at the root or a leaf, but it must follow the parent-child direction.

This problem is a great combination of tree traversal and prefix sum techniques, allowing efficient computation of all possible valid paths.

-> Key Concepts

1. Depth-First Search (DFS)

2. Prefix Sum Optimization

3. Recursive Traversal

4. HashMap for Path Tracking

5. Time Complexity: O(n)

6. Space Complexity: O(n)

-> Example

Input:

root = [10,5,-3,3,2,null,11,3,-2,null,1]
targetSum = 8


Output:

3


Explanation:
The paths that sum to 8 are:

5 → 3

5 → 2 → 1

-3 → 11

-> Algorithm Overview

1. Use DFS traversal to visit every node in the tree.

2. Maintain a prefix sum HashMap that stores the number of times each sum has occurred.

3. At each node, calculate the current sum from the root and check if (currentSum - targetSum) exists in the map.

4. If it exists, that indicates one or more valid paths ending at the current node.

5. Recursively continue traversal for left and right children.

6. Backtrack by removing the current sum before returning to ensure correctness for other paths.